### PR TITLE
Allow `dir` (and other proprety) override in `build_html_enclosing_tag`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Emacs
+*~

--- a/pyhiccup/core.py
+++ b/pyhiccup/core.py
@@ -20,15 +20,15 @@
 #
 ##############################################################################
 from __future__ import unicode_literals
-import logging
+
 import copy
+import logging
 from itertools import chain
 
-from .page import get_doc_type
-from .page import build_html_enclosing_tag, build_xml_enclosing_tag
-from .page import XMl_DECLARATION
+from .page import (XMl_DECLARATION, build_html_enclosing_tag,
+                   build_xml_enclosing_tag, get_doc_type)
 
-_logger = logging.getLogger('pyhiccup.convert')
+_logger = logging.getLogger("pyhiccup.convert")
 
 TREE_TYPE = (list, tuple)
 
@@ -48,8 +48,8 @@ def format_attributes(attributes):
     """
     output = []
     for item in sorted(attributes.items()):
-        output.append('%s=\"%s\"' % item)
-    return " %s" % ' '.join(output)
+        output.append('%s="%s"' % item)
+    return " %s" % " ".join(output)
 
 
 def _convert_tree(node):
@@ -63,7 +63,7 @@ def _convert_tree(node):
     :return: a list of string
     :rtype: list
     """
-    #perfo tweak with side effect
+    # perfo tweak with side effect
     if isinstance(node[0], TREE_TYPE):
         for sub_node in node:
             for x in _convert_tree(sub_node):
@@ -71,9 +71,9 @@ def _convert_tree(node):
         return
     btype = node[0]
     rest = node[1:] if len(node) > 1 else []
-    attrs = ''
+    attrs = ""
     inner_trees = []
-    inner_element = ''
+    inner_element = ""
     for element in rest:
         if not element:
             continue
@@ -87,7 +87,7 @@ def _convert_tree(node):
         else:
             inner_element = element
     if inner_element or inner_trees:
-        yield '<%s%s>' % (
+        yield "<%s%s>" % (
             btype,
             attrs,
         )
@@ -96,9 +96,9 @@ def _convert_tree(node):
             for ext in inner_trees:
                 for x in _convert_tree(ext):
                     yield x
-        yield '</%s>' % btype
+        yield "</%s>" % btype
     else:
-        yield '<%s%s/>' % (
+        yield "<%s%s/>" % (
             btype,
             attrs,
         )
@@ -117,19 +117,13 @@ def _inclose_page(declaration, enclosing_tag, value):
     """
     to_convert = copy.deepcopy(enclosing_tag)
     to_convert.append(value)
-    converted = chain(
-        [declaration],
-        _convert_tree(to_convert)
-    )
+    converted = chain([declaration], _convert_tree(to_convert))
     if _logger.getEffectiveLevel() == logging.DEBUG:
-        _logger.debug(
-            list(chain([declaration],
-                       _convert_tree(to_convert)))
-        )
+        _logger.debug(list(chain([declaration], _convert_tree(to_convert))))
     return converted
 
 
-def html(value, etype='html5', **kwargs):
+def html(value, etype="html5", **kwargs):
     """Transform a list describing HTML to raw HTML
 
     :param value: list of list describing HTML
@@ -146,7 +140,7 @@ def html(value, etype='html5', **kwargs):
     declaration = get_doc_type(etype)
     enclosing_tag = build_html_enclosing_tag(etype)
     converted = _inclose_page(declaration, enclosing_tag, value)
-    return ''.join(converted)
+    return "".join(converted)
 
 
 def xml(value, etype, **kwargs):
@@ -165,7 +159,8 @@ def xml(value, etype, **kwargs):
     declaration = XMl_DECLARATION
     enclosing_tag = build_xml_enclosing_tag(etype, **kwargs)
     converted = _inclose_page(declaration, enclosing_tag, value)
-    return ''.join(converted)
+    return "".join(converted)
+
 
 def convert(value):
     """Transform a list to arbitratry XML
@@ -176,4 +171,4 @@ def convert(value):
     :return: XML string representation
     :rtype: str, unicode
     """
-    return ''.join(_convert_tree(value))
+    return "".join(_convert_tree(value))

--- a/pyhiccup/core.py
+++ b/pyhiccup/core.py
@@ -72,30 +72,22 @@ def _convert_tree(node):
     btype = node[0]
     rest = node[1:] if len(node) > 1 else []
     attrs = ""
-    inner_trees = []
-    inner_element = ""
-    for element in rest:
-        if not element:
-            continue
-        if isinstance(element, TREE_TYPE):
-            if isinstance(element[0], TREE_TYPE):
-                inner_trees.extend(element)
-            else:
-                inner_trees.append(element)
-        elif isinstance(element, dict):
-            attrs = format_attributes(element)
-        else:
-            inner_element = element
-    if inner_element or inner_trees:
+    if rest and type(rest[0]) is dict:
+        attrs = format_attributes(rest[0])
+        rest = rest[1:]
+    if rest:
         yield "<%s%s>" % (
             btype,
             attrs,
         )
-        yield inner_element
-        if inner_trees:
-            for ext in inner_trees:
-                for x in _convert_tree(ext):
-                    yield x
+        for element in rest:
+            if not element:
+                continue
+            elif isinstance(element, TREE_TYPE):
+                for el in _convert_tree(element):
+                    yield el
+            else:
+                yield element
         yield "</%s>" % btype
     else:
         yield "<%s%s/>" % (

--- a/pyhiccup/core.py
+++ b/pyhiccup/core.py
@@ -138,7 +138,7 @@ def html(value, etype="html5", **kwargs):
     :rtype: str, unicode
     """
     declaration = get_doc_type(etype)
-    enclosing_tag = build_html_enclosing_tag(etype)
+    enclosing_tag = build_html_enclosing_tag(etype, **kwargs)
     converted = _inclose_page(declaration, enclosing_tag, value)
     return "".join(converted)
 

--- a/pyhiccup/page.py
+++ b/pyhiccup/page.py
@@ -22,19 +22,17 @@
 from __future__ import unicode_literals
 
 DOC_TYPES = {
-    'html4': "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" "
-             "\"http://www.w3.org/TR/html4/strict.dtd\">\n",
-
-    'xhtml-strict': "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 ""Strict//EN\" "
-                    "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n",
-
-    'xhtml-transitional': "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" "
-                          "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n",
-
-    'html5': "<!DOCTYPE html>\n",
+    "html4": '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" '
+    '"http://www.w3.org/TR/html4/strict.dtd">\n',
+    "xhtml-strict": '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 '
+    'Strict//EN" '
+    '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n',
+    "xhtml-transitional": '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" '
+    '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n',
+    "html5": "<!DOCTYPE html>\n",
 }
 
-DEFAULT_XMLNS = 'http://www.w3.org/1999/xhtml'
+DEFAULT_XMLNS = "http://www.w3.org/1999/xhtml"
 XMl_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>'
 
 
@@ -49,8 +47,7 @@ def get_doc_type(doc_type):
     """
     if doc_type not in DOC_TYPES:
         raise ValueError(
-            'Invalid DOCTYPE %s available values are %s' %
-            (doc_type, DOC_TYPES.keys())
+            "Invalid DOCTYPE %s available values are %s" % (doc_type, DOC_TYPES.keys())
         )
     return DOC_TYPES[doc_type]
 
@@ -69,13 +66,13 @@ def build_html_enclosing_tag(etype, **kwargs):
     """
     attrs = {}
     if etype in DOC_TYPES:
-        attrs['lang'] = 'en'
-        attrs['dir'] = 'rtl'
-        attrs['xml:lang'] = 'en'
-    if 'xhtml' in etype:
-        attrs[u'xmlns'] = DEFAULT_XMLNS
+        attrs["lang"] = "en"
+        attrs["dir"] = "rtl"
+        attrs["xml:lang"] = "en"
+    if "xhtml" in etype:
+        attrs["xmlns"] = DEFAULT_XMLNS
     attrs.update(kwargs)
-    return ['html', attrs]
+    return ["html", attrs]
 
 
 def build_xml_enclosing_tag(etype, **kwargs):

--- a/pyhiccup/page.py
+++ b/pyhiccup/page.py
@@ -67,7 +67,7 @@ def build_html_enclosing_tag(etype, **kwargs):
     attrs = {}
     if etype in DOC_TYPES:
         attrs["lang"] = "en"
-        attrs["dir"] = "rtl"
+        attrs["dir"] = "ltr"
         attrs["xml:lang"] = "en"
     if "xhtml" in etype:
         attrs["xmlns"] = DEFAULT_XMLNS

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ description-file = README.rst
 home-page = http://pypi.python.org/pypi/pyhiccup
 requires-python = >=2.6
 classifier =
-Development Status :: 0.1
+Development Status :: 0.2
 Environment :: Console
 Intended Audience :: Developers
 Operating System :: OS Independent


### PR DESCRIPTION
Before this change:

```
>>> import pyhiccup.core
>>> pyhiccup.core.html("hello there")
'<!DOCTYPE html>\n<html dir="rtl" lang="en" xml:lang="en">hello there</html>'
>>> pyhiccup.core.html("hello there", dir="ltr")
'<!DOCTYPE html>\n<html dir="rtl" lang="en" xml:lang="en">hello there</html>'
>>> 
```

Note that the output still contains `dir="rtl"` instead of accepting the input value of `dir`. This is a result of the function `core.html` not passing `kwargs` to its call of `build_html_enclosing_tag` (see the line affected by [this commit](https://github.com/nbessi/pyhiccup/pull/21/commits/faa4acd0091b2bade177383faa8ce829a983c0b1)).

After this change:

```
>>> import pyhiccup.core
>>> pyhiccup.core.html("hello there")
'<!DOCTYPE html>\n<html dir="rtl" lang="en" xml:lang="en">hello there</html>'
>>> pyhiccup.core.html("hello there", dir="ltr")
'<!DOCTYPE html>\n<html dir="ltr" lang="en" xml:lang="en">hello there</html>'
>>> 
```